### PR TITLE
Fix correct TaskList display issue when list is empty

### DIFF
--- a/src/main/java/utility/TaskList.java
+++ b/src/main/java/utility/TaskList.java
@@ -104,7 +104,7 @@ public class TaskList implements Serializable {
     public String toString() {
         String outputString;
         if (imTaskList.size() == 0) {
-            outputString = "No tasks! What tasks would you like to add?\n";
+            return outputString = "No tasks! What tasks would you like to add?\n";
         }
         outputString = "Here are your tasks in your list:\n"
             + IntStream.rangeClosed(1, imTaskList.size())

--- a/src/test/java/utility/TaskListTest.java
+++ b/src/test/java/utility/TaskListTest.java
@@ -14,6 +14,7 @@ public class TaskListTest {
     public void indexingTest() {
         TaskList taskList = new TaskList();
         assertEquals(0, taskList.size());
+        assertEquals("No tasks! What tasks would you like to add?\n", taskList.toString());
         assertFalse(taskList.isValidIndex(0));
         taskList = taskList.addTask(new Task("test", new Tag()));
         assertFalse(taskList.isValidIndex(1));


### PR DESCRIPTION
- Fixed bug where TaskList does not display properly when the list command is executed from a fresh start or after all tasks are deleted.
- Ensured TaskList shows an appropriate message when no tasks are present.